### PR TITLE
Citation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # Google-Map-to-Victorian-ECR-Hospitals
+
 Map of traveling time to Victorian ECR Hospitals
+
+[Interactive maps of ECR hospital catchment basins](https://gntem2.github.io/Google-Map-to-Victorian-ECR-Hospitals/)

--- a/referencing/index.md
+++ b/referencing/index.md
@@ -14,7 +14,7 @@ This work is described in the following publication:
 
 ## Citation links
 
-[Citing - Google Scholar](https://scholar.google.com.au/scholar?hl=en&q=Googling+Service+Boundaries+for+Endovascular+Clot+Retrieval+Hub+Hospitals+in+a+Metropolitan+Setting&btnG=&as_sdt=1%2C5&as_sdtp=#)
+[Google Scholar](https://scholar.google.com.au/scholar?hl=en&q=Googling+Service+Boundaries+for+Endovascular+Clot+Retrieval+Hub+Hospitals+in+a+Metropolitan+Setting&btnG=&as_sdt=1%2C5&as_sdtp=#)
 
 
 [Endnote citation](https://scholar.googleusercontent.com/scholar.enw?q=info:wGoLJV0dMWkJ:scholar.google.com/&output=citation&scisig=AAGBfm0AAAAAWOLlKpzHMHzeN_bddhOdnGHDAMzWEX5b&scisf=3&ct=citation&cd=-1&hl=en)

--- a/referencing/index.md
+++ b/referencing/index.md
@@ -10,4 +10,6 @@ title: ECR service modelling citation
 This work is described in the following publication:
 
 
-Links to pubmed, journal etc.
+[Googling Service Boundaries for Endovascular CLot Retrieval Hub Hospitals in a Metropolitan Setting. Proof-of-Concept Study](http://stroke.ahajournals.org/content/early/2017/03/29/STROKEAHA.116.015323)
+
+[Citing](https://scholar.google.com.au/scholar?hl=en&q=Googling+Service+Boundaries+for+Endovascular+CLot+Retrieval+Hub+Hospitals+in+a+Metropolitan+Setting&btnG=&as_sdt=1%2C5&as_sdtp=#)

--- a/referencing/index.md
+++ b/referencing/index.md
@@ -12,7 +12,10 @@ This work is described in the following publication:
 
 [Googling Service Boundaries for Endovascular CLot Retrieval Hub Hospitals in a Metropolitan Setting. Proof-of-Concept Study](http://stroke.ahajournals.org/content/early/2017/03/29/STROKEAHA.116.015323)
 
+## Citation links
+
 [Citing - Google Scholar](https://scholar.google.com.au/scholar?hl=en&q=Googling+Service+Boundaries+for+Endovascular+Clot+Retrieval+Hub+Hospitals+in+a+Metropolitan+Setting&btnG=&as_sdt=1%2C5&as_sdtp=#)
+
 
 [Endnote citation](https://scholar.googleusercontent.com/scholar.enw?q=info:wGoLJV0dMWkJ:scholar.google.com/&output=citation&scisig=AAGBfm0AAAAAWOLlKpzHMHzeN_bddhOdnGHDAMzWEX5b&scisf=3&ct=citation&cd=-1&hl=en)
 

--- a/referencing/index.md
+++ b/referencing/index.md
@@ -12,4 +12,12 @@ This work is described in the following publication:
 
 [Googling Service Boundaries for Endovascular CLot Retrieval Hub Hospitals in a Metropolitan Setting. Proof-of-Concept Study](http://stroke.ahajournals.org/content/early/2017/03/29/STROKEAHA.116.015323)
 
-[Citing](https://scholar.google.com.au/scholar?hl=en&q=Googling+Service+Boundaries+for+Endovascular+CLot+Retrieval+Hub+Hospitals+in+a+Metropolitan+Setting&btnG=&as_sdt=1%2C5&as_sdtp=#)
+[Citing - Google Scholar](https://scholar.google.com.au/scholar?hl=en&q=Googling+Service+Boundaries+for+Endovascular+Clot+Retrieval+Hub+Hospitals+in+a+Metropolitan+Setting&btnG=&as_sdt=1%2C5&as_sdtp=#)
+
+[Endnote citation](https://scholar.googleusercontent.com/scholar.enw?q=info:wGoLJV0dMWkJ:scholar.google.com/&output=citation&scisig=AAGBfm0AAAAAWOLlKpzHMHzeN_bddhOdnGHDAMzWEX5b&scisf=3&ct=citation&cd=-1&hl=en)
+
+[Bibtex citation](https://scholar.googleusercontent.com/scholar.bib?q=info:wGoLJV0dMWkJ:scholar.google.com/&output=citation&scisig=AAGBfm0AAAAAWOLlKpzHMHzeN_bddhOdnGHDAMzWEX5b&scisf=4&ct=citation&cd=-1&hl=en)
+
+[RefMan citation](https://scholar.googleusercontent.com/scholar.ris?q=info:wGoLJV0dMWkJ:scholar.google.com/&output=citation&scisig=AAGBfm0AAAAAWOLlKpzHMHzeN_bddhOdnGHDAMzWEX5b&scisf=2&ct=citation&cd=-1&hl=en)
+
+[RefWorks citation](https://scholar.googleusercontent.com/scholar.rfw?q=info:wGoLJV0dMWkJ:scholar.google.com/&output=citation&scisig=AAGBfm0AAAAAWOLlKpzHMHzeN_bddhOdnGHDAMzWEX5b&scisf=1&ct=citation&cd=-1&hl=en)

--- a/referencing/index.md
+++ b/referencing/index.md
@@ -10,7 +10,7 @@ title: ECR service modelling citation
 This work is described in the following publication:
 
 
-[Googling Service Boundaries for Endovascular CLot Retrieval Hub Hospitals in a Metropolitan Setting. Proof-of-Concept Study](http://stroke.ahajournals.org/content/early/2017/03/29/STROKEAHA.116.015323)
+[Googling Service Boundaries for Endovascular Clot Retrieval Hub Hospitals in a Metropolitan Setting. Proof-of-Concept Study](http://stroke.ahajournals.org/content/early/2017/03/29/STROKEAHA.116.015323)
 
 ## Citation links
 


### PR DESCRIPTION
Updates to the citations part.

There are now links to the article under the citation parts, as well as links to generate citations for endnote etc